### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/src/main/@orb.yml
+++ b/src/main/@orb.yml
@@ -1,2 +1,5 @@
 version: 2.1
-description: Detect bugs and vulnerabilities in your repository. This orb is created by SonarSource (https://www.sonarsource.com/), the source is available at https://github.com/SonarSource/sonarcloud-circleci-orb
+description: Detect bugs and vulnerabilities in your repository.
+display:
+  home_url: https://www.sonarsource.com/
+  source_url: https://github.com/SonarSource/sonarcloud-circleci-orb


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.