### PR TITLE
Allow user to specify a path to the sonar-scanner project config to use

### DIFF
--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -4,6 +4,10 @@ parameters:
     description: the name of the environment variable where the SonarCloud API token is stored 
     default: SONAR_TOKEN
     type: env_var_name
+  sonar_config_path:
+    description: path to the sonnar-scanner config to use (e.g. ~/my-repo-configs/.sonarcloud.properties)
+    default: ""
+    type: string
   cache_version:
     description: increment this value if the cache is corrupted and you want to start with a clean cache
     default: 1
@@ -30,11 +34,15 @@ steps:
           curl -Ol https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-$VERSION-$OS.zip
           unzip -qq -o sonar-scanner-cli-$VERSION-$OS.zip -d $SCANNER_DIRECTORY
         fi
-        
+
         chmod +x $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner
         chmod +x $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/jre/bin/java
 
-        $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner
+        if [ ! -z "<<parameters.sonar_config_path>>" ]; then
+          $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner -Dproject.settings=<<parameters.sonar_config_path>>
+        else
+          $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner
+        fi
       environment:
         SONARQUBE_SCANNER_PARAMS: '{"sonar.host.url":"https://sonarcloud.io"}'
   - save_cache:


### PR DESCRIPTION
This pull request adds new ``sonar_config_path`` command parameter with which user can specify path to the config file which will be used with the ``sonar-scanner`` binary (aka value for the ``-Dproject.settings`` CLI argument).

## Background, Context

Right now this orb is very inflexible and it doesn't allow user to specify path to the config it should be used.

By default, it looks for the config file in ``SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS`` directory, but that is no use to the end user because this orb downloads and runs sonar-scanner as part of a single command.

This means you can't have additional step in the job which would do something like ``cp /path/to/my/custom/config SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/sonar-project.properties``.

I believe allowing user to specify custom path to the config is the most ideal scenario and gives user the most flexibility since most of the settings can be specified in this config and there is no need to define custom command parameter for each of the possible settings.

## TODO

- [ ] Docs, examples (in case people are fine with this change)