### PR TITLE
Add Home URL and Source Code URL (copy of #4)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ workflows:
           requires: [orb-tools/publish-dev]
       - orb-tools/publish:
           context: Publishing Orb
-          orb-ref: sonarsource/sonarcloud@1.0.1
+          orb-ref: sonarsource/sonarcloud@1.0.2
           attach-workspace: true
           requires: [test-node, test-circleci-python]
           filters:

--- a/src/main/@orb.yml
+++ b/src/main/@orb.yml
@@ -1,2 +1,5 @@
 version: 2.1
-description: Detect bugs and vulnerabilities in your repository. This orb is created by SonarSource (https://www.sonarsource.com/), the source is available at https://github.com/SonarSource/sonarcloud-circleci-orb
+description: Detect bugs and vulnerabilities in your repository.
+display:
+  home_url: https://www.sonarcloud.io/
+  source_url: https://github.com/SonarSource/sonarcloud-circleci-orb


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.