### PR TITLE
Fix resolving the custom environment variable to pass the sonar token

### DIFF
--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -24,7 +24,8 @@ steps:
       command: |
         set -e
         VERSION=5.0.1.3006
-        SONAR_TOKEN=${<< parameters.sonar_token_variable_name >>}
+        echo "export SONAR_TOKEN=${<< parameters.sonar_token_variable_name >>}" >> "$BASH_ENV"
+        [ -f "${BASH_ENV}" ] && . "${BASH_ENV}"
         SCANNER_DIRECTORY=/tmp/cache/scanner
         export SONAR_USER_HOME=$SCANNER_DIRECTORY/.sonar
         OS="linux"

--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -1,7 +1,7 @@
 description: Detect bugs and vulnerabilities
 parameters:
   sonar_token_variable_name:
-    description: the name of the environment variable where the SonarCloud API token is stored 
+    description: the name of the environment variable where the SonarCloud API token is stored
     default: SONAR_TOKEN
     type: env_var_name
   cache_version:
@@ -24,7 +24,7 @@ steps:
       command: |
         set -e
         VERSION=5.0.1.3006
-        SONAR_TOKEN=$<<parameters.sonar_token_variable_name>>
+        SONAR_TOKEN=${<< parameters.sonar_token_variable_name >>}
         SCANNER_DIRECTORY=/tmp/cache/scanner
         export SONAR_USER_HOME=$SCANNER_DIRECTORY/.sonar
         OS="linux"


### PR DESCRIPTION
Currently passing a custom environment variable to the orb that contains the Sonar token does not work due to incorrectly resolving the value. This PR addresses that problem.