### PR TITLE
Update release to 2.0.0 with sonarcloud-scanner:5.0.0.2966 that runs scanner with java 17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ workflows:
           requires: [orb-tools/publish-dev]
       - orb-tools/publish:
           context: Publishing Orb
-          orb-ref: sonarsource/sonarcloud@1.1.1
+          orb-ref: sonarsource/sonarcloud@2.0.0
           attach-workspace: true
           requires: [test-node, test-circleci-python]
           filters:

--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -18,12 +18,12 @@ steps:
       command: mkdir -p /tmp/cache/scanner
   - restore_cache:
       keys:
-        - v<<parameters.cache_version>>-sonarcloud-scanner-4.7.0.2747
+        - v<<parameters.cache_version>>-sonarcloud-scanner-5.0.0.2966
   - run:
       name: SonarCloud
       command: |
         set -e
-        VERSION=4.7.0.2747
+        VERSION=5.0.0.2966
         SONAR_TOKEN=$<<parameters.sonar_token_variable_name>>
         SCANNER_DIRECTORY=/tmp/cache/scanner
         export SONAR_USER_HOME=$SCANNER_DIRECTORY/.sonar
@@ -43,5 +43,5 @@ steps:
       environment:
         SONARQUBE_SCANNER_PARAMS: '{"sonar.host.url":"https://sonarcloud.io"}'
   - save_cache:
-      key: v<<parameters.cache_version>>-sonarcloud-scanner-4.7.0.2747
+      key: v<<parameters.cache_version>>-sonarcloud-scanner-5.0.0.2966
       paths: /tmp/cache/scanner


### PR DESCRIPTION
We noticed that circle.ci scan result is showing a warning message on our PR as the following screenshot:
<img width="958" alt="image" src="https://github.com/SonarSource/sonarcloud-circleci-orb/assets/46878464/49ff2fea-ab16-412a-8746-872d48c1a80d">

The current latest orb in circle.ci is using scanner "[4.7.0.2747](https://github.com/SonarSource/sonar-scanner-cli/releases/tag/4.7.0.2747)" which uses java 11.

So proposed to release a new version that uses the latest "5.0.0.2966" version that uses java 17.

Since it is a major version code update in the sonarcloud-scanner, so this PR proposed to use version 2.0.0 as well.