### PR TITLE
fix: make `sonar_token_variable_name` parameter work

### DIFF
--- a/src/commands/scan.yml
+++ b/src/commands/scan.yml
@@ -22,6 +22,7 @@ steps:
   - run:
       name: SonarQube Cloud
       environment:
+        SONAR_TOKEN_VARIABLE_NAME: <<pipeline.parameters.sonar_token_variable_name>>
         PROJECT_ROOT: <<parameters.project_root>>
       command: <<include(scripts/scan.sh)>>
   - save_cache:

--- a/src/scripts/scan.sh
+++ b/src/scripts/scan.sh
@@ -2,7 +2,8 @@
 
 set -e
 VERSION=7.1.0.4889
-SONAR_TOKEN=${SONAR_TOKEN:?Environment variable SONAR_TOKEN is required}
+SONAR_TOKEN_VARIABLE_NAME=${SONAR_TOKEN_VARIABLE_NAME:?Environment variable SONAR_TOKEN_VARIABLE_NAME is required}
+SONAR_TOKEN=$(printenv "$SONAR_TOKEN_VARIABLE_NAME" 2>/dev/null || { echo "Environment variable $SONAR_TOKEN_VARIABLE_NAME is required" >&2; exit 1; })
 SCANNER_DIRECTORY=/tmp/cache/scanner
 export SONAR_USER_HOME=$SCANNER_DIRECTORY/.sonar
 OS="linux"


### PR DESCRIPTION
## Problem

The `sonar_token_variable_name` parameter is declared in the docs but is not actually used by the orb. The script still strictly requires the token to be stored in `SONAR_TOKEN` variable.

## Solution

Make the script use `SONAR_TOKEN_VARIABLE_NAME` all the time.
If the user does not provide the value, it defaults to `SONAR_TOKEN` as planned.