### PR TITLE
SCCIRCLE-21 Fix the Analysis Processing team name in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/CODEOWNERS @sonarsource/orchestration-processing-squad
+.github/CODEOWNERS @sonarsource/quality-processing-squad


### PR DESCRIPTION
## Summary
- Updated the GitHub team reference in `.github/CODEOWNERS` from `orchestration-processing-squad` to `quality-processing-squad`

## Details
The Github team `orchestration-processing-squad` has been renamed to `quality-processing-squad` due to the move from the Code Orchestration team to Code Quality.

Fixes: SC-41026

## Test plan
- [x] Updated CODEOWNERS file with new team name

🤖 Generated with [Claude Code](https://claude.com/claude-code)