### PR TITLE
id:150126 fix(scanner): upgrade sonar-scanner-cli to 7.3.0.5189 for java 21 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
           orb-name: elateral/sonarqube-scanner
           requires: [orb-tools/pack]
       - orb-tools/publish:
-          orb-ref: elateral/sonarqube-scanner@1.1.0
+          orb-ref: elateral/sonarqube-scanner@1.2.0
           attach-workspace: true
           requires: [orb-tools/publish-dev]
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
           orb-name: elateral/sonarqube-scanner
           requires: [orb-tools/pack]
       - orb-tools/publish:
-          orb-ref: elateral/sonarqube-scanner@0.0.12
+          orb-ref: elateral/sonarqube-scanner@0.0.13
           attach-workspace: true
           requires: [orb-tools/publish-dev]
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
           orb-name: elateral/sonarqube-scanner
           requires: [orb-tools/pack]
       - orb-tools/publish:
-          orb-ref: elateral/sonarqube-scanner@0.0.4
+          orb-ref: elateral/sonarqube-scanner@0.0.5
           attach-workspace: true
           requires: [orb-tools/publish-dev]
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ workflows:
           workspace-path: orb.yml
           artifact-path: orb.yml
       - orb-tools/publish-dev:
-          context: Publishing Orb
+         # context: Publishing Orb
           orb-name: elateral/sonarqube-scanner
           requires: [orb-tools/pack]
       - test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
           orb-name: elateral/sonarqube-scanner
           requires: [orb-tools/pack]
       - orb-tools/publish:
-          orb-ref: elateral/sonarqube-scanner@0.0.11
+          orb-ref: elateral/sonarqube-scanner@0.0.12
           attach-workspace: true
           requires: [orb-tools/publish-dev]
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  orb-tools: circleci/orb-tools@8.27.4
+  orb-tools: circleci/orb-tools@10.1.0
 jobs:
   test:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
           orb-name: elateral/sonarqube-scanner
           requires: [orb-tools/pack]
       - orb-tools/publish:
-          orb-ref: elateral/sonarqube-scanner@0.0.9
+          orb-ref: elateral/sonarqube-scanner@0.0.10
           attach-workspace: true
           requires: [orb-tools/publish-dev]
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
           orb-name: elateral/sonarqube-scanner
           requires: [orb-tools/pack]
       - orb-tools/publish:
-          orb-ref: elateral/sonarqube-scanner@0.0.13
+          orb-ref: elateral/sonarqube-scanner@0.0.14
           attach-workspace: true
           requires: [orb-tools/publish-dev]
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
           orb-name: elateral/sonarqube-scanner
           requires: [orb-tools/pack]
       - orb-tools/publish:
-          orb-ref: elateral/sonarqube-scanner@0.0.6
+          orb-ref: elateral/sonarqube-scanner@0.0.7
           attach-workspace: true
           requires: [orb-tools/publish-dev]
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,21 +22,11 @@ workflows:
          # context: Publishing Orb
           orb-name: elateral/sonarqube-scanner
           requires: [orb-tools/pack]
-      - test:
-          name: test-node
-          image: node
-          context: SonarCloud Analysis
-          requires: [orb-tools/publish-dev]
-      - test:
-          name: test-circleci-python
-          image: circleci/python
-          context: SonarCloud Analysis
-          requires: [orb-tools/publish-dev]
       - orb-tools/publish:
           context: Publishing Orb
           orb-ref: elateral/sonarqube-scanner@0.0.2
           attach-workspace: true
-          requires: [test-node, test-circleci-python]
+          requires: [orb-tools/publish-dev]
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
           orb-name: elateral/sonarqube-scanner
           requires: [orb-tools/pack]
       - orb-tools/publish:
-          orb-ref: elateral/sonarqube-scanner@1.0.0
+          orb-ref: elateral/sonarqube-scanner@1.1.0
           attach-workspace: true
           requires: [orb-tools/publish-dev]
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ workflows:
           artifact-path: orb.yml
       - orb-tools/publish-dev:
          # context: Publishing Orb
+          orb-ref: elateral/sonarqube-scanner@1.0.0-alpha
           orb-name: elateral/sonarqube-scanner
           requires: [orb-tools/pack]
       - orb-tools/publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
           orb-name: elateral/sonarqube-scanner
           requires: [orb-tools/pack]
       - orb-tools/publish:
-          orb-ref: elateral/sonarqube-scanner@0.0.7
+          orb-ref: elateral/sonarqube-scanner@0.0.8
           attach-workspace: true
           requires: [orb-tools/publish-dev]
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 orbs:
   orb-tools: circleci/orb-tools@8.27.4
-  sonarcloud: sonarsource/sonarcloud@dev:alpha
 jobs:
   test:
     parameters:
@@ -11,7 +10,6 @@ jobs:
       - image: <<parameters.image>>:latest
     steps:
       - checkout
-      - sonarcloud/scan
 workflows:
   publish-dev:
     jobs:
@@ -22,7 +20,7 @@ workflows:
           artifact-path: orb.yml
       - orb-tools/publish-dev:
           context: Publishing Orb
-          orb-name: sonarsource/sonarcloud
+          orb-name: elateral/sonarqube-scanner
           requires: [orb-tools/pack]
       - test:
           name: test-node
@@ -36,7 +34,7 @@ workflows:
           requires: [orb-tools/publish-dev]
       - orb-tools/publish:
           context: Publishing Orb
-          orb-ref: sonarsource/sonarcloud@1.0.2
+          orb-ref: elateral/sonarqube-scanner@0.0.2
           attach-workspace: true
           requires: [test-node, test-circleci-python]
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
           orb-name: elateral/sonarqube-scanner
           requires: [orb-tools/pack]
       - orb-tools/publish:
-          orb-ref: elateral/sonarqube-scanner@0.0.3
+          orb-ref: elateral/sonarqube-scanner@0.0.4
           attach-workspace: true
           requires: [orb-tools/publish-dev]
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
           orb-name: elateral/sonarqube-scanner
           requires: [orb-tools/pack]
       - orb-tools/publish:
-          orb-ref: elateral/sonarqube-scanner@0.0.14
+          orb-ref: elateral/sonarqube-scanner@1.0.0
           attach-workspace: true
           requires: [orb-tools/publish-dev]
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
           orb-name: elateral/sonarqube-scanner
           requires: [orb-tools/pack]
       - orb-tools/publish:
-          orb-ref: elateral/sonarqube-scanner@0.0.2
+          orb-ref: elateral/sonarqube-scanner@0.0.3
           attach-workspace: true
           requires: [orb-tools/publish-dev]
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
         type: string
     docker:
       - image: <<parameters.image>>:latest
-    steps:
+    steps: 
       - checkout
 workflows:
   publish-dev:
@@ -20,7 +20,6 @@ workflows:
           artifact-path: orb.yml
       - orb-tools/publish-dev:
          # context: Publishing Orb
-          orb-ref: elateral/sonarqube-scanner@1.0.0-alpha
           orb-name: elateral/sonarqube-scanner
           requires: [orb-tools/pack]
       - orb-tools/publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
           orb-name: elateral/sonarqube-scanner
           requires: [orb-tools/pack]
       - orb-tools/publish:
-          orb-ref: elateral/sonarqube-scanner@0.0.8
+          orb-ref: elateral/sonarqube-scanner@0.0.9
           attach-workspace: true
           requires: [orb-tools/publish-dev]
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
           orb-name: elateral/sonarqube-scanner
           requires: [orb-tools/pack]
       - orb-tools/publish:
-          orb-ref: elateral/sonarqube-scanner@0.0.5
+          orb-ref: elateral/sonarqube-scanner@0.0.6
           attach-workspace: true
           requires: [orb-tools/publish-dev]
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ workflows:
           orb-name: elateral/sonarqube-scanner
           requires: [orb-tools/pack]
       - orb-tools/publish:
-          context: Publishing Orb
           orb-ref: elateral/sonarqube-scanner@0.0.2
           attach-workspace: true
           requires: [orb-tools/publish-dev]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
           orb-name: elateral/sonarqube-scanner
           requires: [orb-tools/pack]
       - orb-tools/publish:
-          orb-ref: elateral/sonarqube-scanner@0.0.10
+          orb-ref: elateral/sonarqube-scanner@0.0.11
           attach-workspace: true
           requires: [orb-tools/publish-dev]
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
           orb-name: elateral/sonarqube-scanner
           requires: [orb-tools/pack]
       - orb-tools/publish:
-          orb-ref: elateral/sonarqube-scanner@1.2.0
+          orb-ref: elateral/sonarqube-scanner@1.3.0
           attach-workspace: true
           requires: [orb-tools/publish-dev]
           filters:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To connect to your SonarCloud project on `sonarcloud.io` you need to setup an ap
 ```yaml
 version: 2.1
 orbs:
-  sonarqube: elateral/sonarqube-scanner@1.0.0
+  sonarqube: elateral/sonarqube-scanner@1.2.0
 jobs:
   build:
     docker:

--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
 # sonarcloud-circleci-orb
 Support of SonarScanner CLI in CircleCI
 
-## SonarCloud Orb
-The SonarCloud Orb can be used with any linux based docker image that includes the command line tools `curl` and `unzip`.
+## SonarQube Orb
+The SonarQube Orb can be used with any linux based docker image that includes the command line tools `curl` and `unzip`.
 
 To connect to your SonarCloud project on `sonarcloud.io` you need to setup an api token. We recommend to setup a CircleCI context in your organization named `sonarcloud` that contains a variable with key `SONAR_TOKEN` and the api token as the value.
 ### Usage examples
 ```yaml
 version: 2.1
 orbs:
-  sonarcloud: sonarsource/sonarcloud@1.0.0
+  sonarqube: elateral/sonarqube-scanner@1.0.0
 jobs:
   build:
     docker:
       - image: 'circleci/python:3.7.4'
     steps:
     - checkout
-    - sonarcloud/scan
+    - sonarqube/scan
 workflows:
   my-workflow:
     jobs:
       - build:
-          context: sonarcloud
+          context: sonarqube
 ```
 
 ### Publishing a new version

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To connect to your SonarCloud project on `sonarcloud.io` you need to setup an ap
 ```yaml
 version: 2.1
 orbs:
-  sonarqube: elateral/sonarqube-scanner@1.2.0
+  sonarqube: elateral/sonarqube-scanner@1.3.0
 jobs:
   build:
     docker:

--- a/src/main/@orb.yml
+++ b/src/main/@orb.yml
@@ -1,5 +1,5 @@
 version: 2.1
 description: Detect bugs and vulnerabilities in your repository.
 display:
-  home_url: https://www.sonarcloud.io/
-  source_url: https://github.com/SonarSource/sonarcloud-circleci-orb
+  home_url: https://www.sonarqube.com/
+  source_url: https://github.com/ElateralLtd/sonarcloud-circleci-orb

--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -18,12 +18,12 @@ steps:
       command: mkdir -p /tmp/cache/scanner
   - restore_cache:
       keys:
-        - v<<parameters.cache_version>>-sonarqube-scanner-4.8.0.2856
+        - v<<parameters.cache_version>>-sonarqube-scanner-5.0.1.3006
   - run:
       name: SonarQubeScan
       command: |
         set -e
-        VERSION=4.8.0.2856
+        VERSION=5.0.1.3006
         SONAR_TOKEN=$<<parameters.sonar_token_variable_name>>
         SCANNER_DIRECTORY=/tmp/cache/scanner
         export SONAR_USER_HOME=$SCANNER_DIRECTORY/.sonar
@@ -44,5 +44,5 @@ steps:
 #          -Dsonar.dependencyCheck.jsonReportPath=./depCheck/dependency-check-report.json \
 #          -Dsonar.dependencyCheck.htmlReportPath=./depCheck/dependency-check-report.html \
   - save_cache:
-      key: v<<parameters.cache_version>>-sonarqube-scanner-4.8.0.2856
+      key: v<<parameters.cache_version>>-sonarqube-scanner-5.0.1.3006
       paths: /tmp/cache/scanner

--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -44,5 +44,5 @@ steps:
 #          -Dsonar.dependencyCheck.jsonReportPath=./depCheck/dependency-check-report.json \
 #          -Dsonar.dependencyCheck.htmlReportPath=./depCheck/dependency-check-report.html \
   - save_cache:
-      key: v<<parameters.cache_version>>-sonarqube-scanner-4.1.0.1829
+      key: v<<parameters.cache_version>>-sonarqube-scanner-4.7.0.2747
       paths: /tmp/cache/scanner

--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -37,7 +37,7 @@ steps:
         $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner \
           -Dsonar.dependencyCheck.jsonReportPath=./depCheck/dependency-check-report.json \
           -Dsonar.dependencyCheck.htmlReportPath=./depCheck/dependency-check-report.html \
-          -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info
+          -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info \
           -Dsonar.python.xunit.reportPath=$PWD/coverage/unit-tests.xml
   - save_cache:
       key: v<<parameters.cache_version>>-sonarqube-scanner-4.1.0.1829

--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -38,6 +38,7 @@ steps:
           -Dsonar.dependencyCheck.jsonReportPath=./depCheck/dependency-check-report.json \
           -Dsonar.dependencyCheck.htmlReportPath=./depCheck/dependency-check-report.html \
           -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info
+          -Dsonar.python.xunit.reportPath=./coverage/unit-tests.xml
   - save_cache:
       key: v<<parameters.cache_version>>-sonarqube-scanner-4.1.0.1829
       paths: /tmp/cache/scanner

--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -10,7 +10,7 @@ parameters:
     type: integer
   sonar_additional_params:
     description: 
-    default:
+    default: ""
     type: string
 steps:
   - run:

--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -38,7 +38,7 @@ steps:
           -Dsonar.dependencyCheck.jsonReportPath=./depCheck/dependency-check-report.json \
           -Dsonar.dependencyCheck.htmlReportPath=./depCheck/dependency-check-report.html \
           -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info \
-          -Dsonar.python.xunit.reportPath=$PWD/coverage/unit-tests.xml
+          -Dsonar.testExecutionReportPaths=$PWD/coverage/unit-tests.xml
   - save_cache:
       key: v<<parameters.cache_version>>-sonarqube-scanner-4.1.0.1829
       paths: /tmp/cache/scanner

--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -37,8 +37,7 @@ steps:
         $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner \
           -Dsonar.dependencyCheck.jsonReportPath=./depCheck/dependency-check-report.json \
           -Dsonar.dependencyCheck.htmlReportPath=./depCheck/dependency-check-report.html \
-          -Dsonar.javascript.jstestdriver.coveragefile=./coverage/lcov.info \
-          -Dsonar.javascript.lcov.reportPath=./coverage/lcov-report
+          -Dsonar.javascript.lcov.reportPath=./coverage/lcov.info
   - save_cache:
       key: v<<parameters.cache_version>>-sonarqube-scanner-4.1.0.1829
       paths: /tmp/cache/scanner

--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -14,7 +14,7 @@ steps:
       command: mkdir -p /tmp/cache/scanner
   - restore_cache:
       keys:
-        - v<<parameters.cache_version>>-sonarqube-scannerner-4.1.0.1829
+        - v<<parameters.cache_version>>-sonarqube-scanner-4.1.0.1829
   - run:
       name: SonarQubeScan
       command: |
@@ -34,7 +34,7 @@ steps:
         chmod +x $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner
         chmod +x $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/jre/bin/java
 
-        $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner
+        $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner -Dsonar.dependencyCheck.jsonReportPath=./dependency-check.json -Dsonar.dependencyCheck.htmlReportPath=./dependency-check.html
   - save_cache:
-      key: v<<parameters.cache_version>>-sonarqube-scannerner-4.1.0.1829
+      key: v<<parameters.cache_version>>-sonarqube-scanner-4.1.0.1829
       paths: /tmp/cache/scanner

--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -34,7 +34,11 @@ steps:
         chmod +x $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner
         chmod +x $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/jre/bin/java
 
-        $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner -Dsonar.dependencyCheck.jsonReportPath=./depCheck/dependency-check-report.json -Dsonar.dependencyCheck.htmlReportPath=./depCheck/dependency-check-report.html
+        $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner \
+          -Dsonar.dependencyCheck.jsonReportPath=./depCheck/dependency-check-report.json \
+          -Dsonar.dependencyCheck.htmlReportPath=./depCheck/dependency-check-report.html \
+          -Dsonar.javascript.jstestdriver.coveragefile=./coverage/lcov.info \
+          -Dsonar.javascript.lcov.reportPath=./coverage/lcov-report
   - save_cache:
       key: v<<parameters.cache_version>>-sonarqube-scanner-4.1.0.1829
       paths: /tmp/cache/scanner

--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -1,7 +1,7 @@
 description: Detect bugs and vulnerabilities
 parameters:
   sonar_token_variable_name:
-    description: the name of the environment variable where the SonarCloud API token is stored 
+    description: the name of the environment variable where the SonarQube API token is stored 
     default: SONAR_TOKEN
     type: env_var_name
   cache_version:
@@ -14,9 +14,9 @@ steps:
       command: mkdir -p /tmp/cache/scanner
   - restore_cache:
       keys:
-        - v<<parameters.cache_version>>-sonarcloud-scanner-4.1.0.1829
+        - v<<parameters.cache_version>>-sonarqube-scannerner-4.1.0.1829
   - run:
-      name: SonarCloud
+      name: SonarQubeScan
       command: |
         set -e
         VERSION=4.1.0.1829
@@ -35,8 +35,6 @@ steps:
         chmod +x $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/jre/bin/java
 
         $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner
-      environment:
-        SONARQUBE_SCANNER_PARAMS: '{"sonar.host.url":"https://sonarcloud.io"}'
   - save_cache:
-      key: v<<parameters.cache_version>>-sonarcloud-scanner-4.1.0.1829
+      key: v<<parameters.cache_version>>-sonarqube-scannerner-4.1.0.1829
       paths: /tmp/cache/scanner

--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -37,8 +37,7 @@ steps:
         $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner \
           -Dsonar.dependencyCheck.jsonReportPath=./depCheck/dependency-check-report.json \
           -Dsonar.dependencyCheck.htmlReportPath=./depCheck/dependency-check-report.html \
-          -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info \
-          -Dsonar.testExecutionReportPaths=$PWD/coverage/unit-tests.xml
+          -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info
   - save_cache:
       key: v<<parameters.cache_version>>-sonarqube-scanner-4.1.0.1829
       paths: /tmp/cache/scanner

--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -18,12 +18,12 @@ steps:
       command: mkdir -p /tmp/cache/scanner
   - restore_cache:
       keys:
-        - v<<parameters.cache_version>>-sonarqube-scanner-4.7.0.2747
+        - v<<parameters.cache_version>>-sonarqube-scanner-4.8.0.2856
   - run:
       name: SonarQubeScan
       command: |
         set -e
-        VERSION=4.7.0.2747
+        VERSION=4.8.0.2856
         SONAR_TOKEN=$<<parameters.sonar_token_variable_name>>
         SCANNER_DIRECTORY=/tmp/cache/scanner
         export SONAR_USER_HOME=$SCANNER_DIRECTORY/.sonar
@@ -44,5 +44,5 @@ steps:
 #          -Dsonar.dependencyCheck.jsonReportPath=./depCheck/dependency-check-report.json \
 #          -Dsonar.dependencyCheck.htmlReportPath=./depCheck/dependency-check-report.html \
   - save_cache:
-      key: v<<parameters.cache_version>>-sonarqube-scanner-4.7.0.2747
+      key: v<<parameters.cache_version>>-sonarqube-scanner-4.8.0.2856
       paths: /tmp/cache/scanner

--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -34,7 +34,7 @@ steps:
         chmod +x $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner
         chmod +x $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/jre/bin/java
 
-        $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner -Dsonar.dependencyCheck.jsonReportPath=./dependency-check.json -Dsonar.dependencyCheck.htmlReportPath=./dependency-check.html
+        $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner -Dsonar.dependencyCheck.jsonReportPath=./dependency-check-report.json -Dsonar.dependencyCheck.htmlReportPath=./dependency-check-report.html
   - save_cache:
       key: v<<parameters.cache_version>>-sonarqube-scanner-4.1.0.1829
       paths: /tmp/cache/scanner

--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -34,7 +34,7 @@ steps:
         chmod +x $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner
         chmod +x $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/jre/bin/java
 
-        $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner -Dsonar.dependencyCheck.jsonReportPath=./dependency-check-report.json -Dsonar.dependencyCheck.htmlReportPath=./dependency-check-report.html
+        $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner -Dsonar.dependencyCheck.jsonReportPath=./depCheck/dependency-check-report.json -Dsonar.dependencyCheck.htmlReportPath=./depCheck/dependency-check-report.html
   - save_cache:
       key: v<<parameters.cache_version>>-sonarqube-scanner-4.1.0.1829
       paths: /tmp/cache/scanner

--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -35,9 +35,9 @@ steps:
         chmod +x $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/jre/bin/java
 
         $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner \
-          -Dsonar.dependencyCheck.jsonReportPath=./depCheck/dependency-check-report.json \
-          -Dsonar.dependencyCheck.htmlReportPath=./depCheck/dependency-check-report.html \
           -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info
+#          -Dsonar.dependencyCheck.jsonReportPath=./depCheck/dependency-check-report.json \
+#          -Dsonar.dependencyCheck.htmlReportPath=./depCheck/dependency-check-report.html \
   - save_cache:
       key: v<<parameters.cache_version>>-sonarqube-scanner-4.1.0.1829
       paths: /tmp/cache/scanner

--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -18,12 +18,12 @@ steps:
       command: mkdir -p /tmp/cache/scanner
   - restore_cache:
       keys:
-        - v<<parameters.cache_version>>-sonarqube-scanner-4.1.0.1829
+        - v<<parameters.cache_version>>-sonarqube-scanner-4.7.0.2747
   - run:
       name: SonarQubeScan
       command: |
         set -e
-        VERSION=4.1.0.1829
+        VERSION=4.7.0.2747
         SONAR_TOKEN=$<<parameters.sonar_token_variable_name>>
         SCANNER_DIRECTORY=/tmp/cache/scanner
         export SONAR_USER_HOME=$SCANNER_DIRECTORY/.sonar

--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -37,7 +37,7 @@ steps:
         $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner \
           -Dsonar.dependencyCheck.jsonReportPath=./depCheck/dependency-check-report.json \
           -Dsonar.dependencyCheck.htmlReportPath=./depCheck/dependency-check-report.html \
-          -Dsonar.javascript.lcov.reportPath=./coverage/lcov.info
+          -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info
   - save_cache:
       key: v<<parameters.cache_version>>-sonarqube-scanner-4.1.0.1829
       paths: /tmp/cache/scanner

--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -38,7 +38,7 @@ steps:
           -Dsonar.dependencyCheck.jsonReportPath=./depCheck/dependency-check-report.json \
           -Dsonar.dependencyCheck.htmlReportPath=./depCheck/dependency-check-report.html \
           -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info
-          -Dsonar.python.xunit.reportPath=./coverage/unit-tests.xml
+          -Dsonar.python.xunit.reportPath=$PWD/coverage/unit-tests.xml
   - save_cache:
       key: v<<parameters.cache_version>>-sonarqube-scanner-4.1.0.1829
       paths: /tmp/cache/scanner

--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -8,6 +8,10 @@ parameters:
     description: increment this value if the cache is corrupted and you want to start with a clean cache
     default: 1
     type: integer
+  sonar_additional_params:
+    description: 
+    default:
+    type: string
 steps:
   - run:
       name: Create cache directory if it doesn't exist
@@ -35,7 +39,8 @@ steps:
         chmod +x $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/jre/bin/java
 
         $SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner \
-          -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info
+          -Dsonar.javascript.lcov.reportPaths=./coverage/lcov.info \
+          <<parameters.sonar_additional_params>>
 #          -Dsonar.dependencyCheck.jsonReportPath=./depCheck/dependency-check-report.json \
 #          -Dsonar.dependencyCheck.htmlReportPath=./depCheck/dependency-check-report.html \
   - save_cache:

--- a/src/main/commands/scan.yml
+++ b/src/main/commands/scan.yml
@@ -18,16 +18,16 @@ steps:
       command: mkdir -p /tmp/cache/scanner
   - restore_cache:
       keys:
-        - v<<parameters.cache_version>>-sonarqube-scanner-5.0.1.3006
+        - v<<parameters.cache_version>>-sonarqube-scanner-7.3.0.5189
   - run:
       name: SonarQubeScan
       command: |
         set -e
-        VERSION=5.0.1.3006
+        VERSION=7.3.0.5189
         SONAR_TOKEN=$<<parameters.sonar_token_variable_name>>
         SCANNER_DIRECTORY=/tmp/cache/scanner
         export SONAR_USER_HOME=$SCANNER_DIRECTORY/.sonar
-        OS="linux"
+        OS="linux-x64"
         echo $SONAR_USER_HOME
 
         if [[ ! -x "$SCANNER_DIRECTORY/sonar-scanner-$VERSION-$OS/bin/sonar-scanner" ]]; then
@@ -44,5 +44,5 @@ steps:
 #          -Dsonar.dependencyCheck.jsonReportPath=./depCheck/dependency-check-report.json \
 #          -Dsonar.dependencyCheck.htmlReportPath=./depCheck/dependency-check-report.html \
   - save_cache:
-      key: v<<parameters.cache_version>>-sonarqube-scanner-5.0.1.3006
+      key: v<<parameters.cache_version>>-sonarqube-scanner-7.3.0.5189
       paths: /tmp/cache/scanner

--- a/src/main/examples/scan-docker.yml
+++ b/src/main/examples/scan-docker.yml
@@ -9,7 +9,7 @@ usage:
       - checkout
       - sonarscan/scan
   orbs:
-    sonarscan: elateral/sonarqube-scanner@1.0.0
+    sonarscan: elateral/sonarqube-scanner@1.2.0
   workflows:
     main:
       jobs:

--- a/src/main/examples/scan-docker.yml
+++ b/src/main/examples/scan-docker.yml
@@ -7,11 +7,11 @@ usage:
         - image: node:latest
       steps:
       - checkout
-      - sonarcloud/scan
+      - sonarscan/scan
   orbs:
-    sonarcloud: sonarsource/sonarcloud@1.0.0
+    sonarscan: elateral/sonarqube-scanner@1.0.0
   workflows:
     main:
       jobs:
         - build:
-            context: sonarcloud
+            context: sonarscan


### PR DESCRIPTION
## Summary
- SonarQube Cloud has dropped support for analyses run under Java 17 (`account-service` CI is currently failing with `EXECUTION FAILURE: The version of Java (17) used to run this analysis is deprecated`).
- The orb was pinned to `sonar-scanner-cli 5.0.1.3006`, which bundles a Java 17 JRE and runs the whole analysis in it — it predates JRE auto-provisioning (introduced in scanner-cli 6.0).
- Bumps to `sonar-scanner-cli 7.3.0.5189`, which auto-provisions a compliant JRE for the analysis engine at scan time (bootstrap JVM only needs Java 11+, satisfied by its own bundled bootstrap JRE).
- Updates the download filename pattern (`-linux` → `-linux-x64`, changed upstream) and bumps the orb release version to `1.3.0`.

## Test plan
- [ ] Merge to `master` and confirm `orb-tools/publish` publishes `elateral/sonarqube-scanner@1.3.0`
- [ ] Point a consuming service (e.g. `account-service`) at `@1.3.0` and confirm the `sonarcloud` CI job passes